### PR TITLE
Fine tune email and phonenumber analyzers 

### DIFF
--- a/types/webpage/esMapping-dig-Ads-DT.json
+++ b/types/webpage/esMapping-dig-Ads-DT.json
@@ -207,7 +207,17 @@
                            },
                            "emailaddress": {
                               "type": "string",
-                              "index": "not_analyzed"
+                              "index": "not_analyzed",
+                              "fields": {
+                                "partial": {
+                                  "type": "string",
+                                  "analyzer": "partial_email_analyzer"
+                                },
+                                "exact": {
+                                  "type": "string",
+                                  "analyzer": "exact_email_analyzer"
+                                }
+                              }
                            },
                            "featureName": {
                               "type": "string",
@@ -1598,8 +1608,17 @@
                               
                            },
                            "phonenumber": {
-                              "type": "string"
-                              
+                              "type": "string",
+                              "fields": {
+                                "partial": {
+                                  "type": "string",
+                                  "analyzer": "partial_phone_analyzer"
+                                },
+                                "exact": {
+                                  "type": "string",
+                                  "analyzer": "exact_phone_analyzer"
+                                }
+                             }
                            },
                            "uri": {
                               "type": "string",
@@ -2225,6 +2244,39 @@
             "filter_stemmer",
             "shingle_filter_4"
           ]
+        },
+        "exact_email_analyzer": {
+          "tokenizer": "uax_url_email",
+          "filter": [
+            "email_splitting_filter_keep_original",
+            "lowercase",
+            "unique"
+          ]
+        },
+        "partial_email_analyzer": {
+          "tokenizer": "uax_url_email",
+          "filter": [
+            "email_splitting_filter",
+            "lowercase"
+          ],
+         "filter": [
+            "ngram_5_8"
+          ]
+        },
+        "partial_phone_analyzer": {
+          "tokenizer": "keyword",
+          "char_filter": [
+            "digits_only"
+          ],
+          "filter": [
+            "ngram_3_10"
+          ]
+        },
+        "exact_phone_analyzer": {
+          "tokenizer": "keyword",
+          "char_filter": [
+            "digits_only"
+          ]
         }
       },
       "filter": {
@@ -2243,9 +2295,42 @@
           "min_shingle_size": 4,
           "max_shingle_size": 4,
           "output_unigrams": false
+        },
+        "email_splitting_filter_keep_original": {
+          "type": "pattern_capture",
+          "preserve_original": 1,
+          "patterns": [
+            "(.+)@",
+            "@(.+)"
+          ]
+        },
+        "email_splitting_filter": {
+          "type": "pattern_capture",
+          "preserve_original": 0,
+          "patterns": [
+            "(.+)@",
+            "@(.+)"
+          ]
+        },
+        "ngram_3_10": {
+          "type": "nGram",
+          "min_gram": 3,
+          "max_gram": 10
+        },
+        "ngram_5_8": {
+          "type": "nGram",
+          "min_gram": 5,
+          "max_gram": 8
+        }
+      },
+      "char_filter": {
+        "digits_only": {
+          "type": "pattern_replace",
+          "pattern": "(\\D)",
+          "replacement": ""
         }
       }
     }
-  
+  }
 }
 }


### PR DESCRIPTION
Updated email and phone number analyzers to support partial matches and noisy human-specified phone number formats.

Rather than just querying the '_all' field, use the following query (note incoming query has to be copied to two locations:

```
{
    "query" : {
        "bool" : {
            "should" : [
                {
                    "query_string" : {
                        "fields" : [
                            "hasFeatureCollection.place_postalAddress_feature.featureValue",
                            "hasFeatureCollection.emailaddress_feature.emailaddress.exact^2.0",
                            "hasFeatureCollection.emailaddress_feature.emailaddress.partial^2.0",
                            "hasTitlePart.text",
                            "hasBodyPart.text"
                        ],
                        "analyzer" : "standard",
                        "default_operator" : "AND", 
                        "query" : "toronto montreal visiting 647"
                    }
                },{
                    "query_string" : {
                        "fields" : [
                            "hasFeatureCollection.phonenumber_feature.phonenumber.exact^3.0",
                            "hasFeatureCollection.phonenumber_feature.phonenumber.partial^3.0"
                        ],
                        "query" : "toronto montreal visiting 647"
                    }
                }
            ]
        }
    }
}
```
